### PR TITLE
Fix failure on make -j >1 as build_ext needs the result of cython

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cython:
 	cython --version
 	cython --cplus --fast-fail --annotate plyvel/_plyvel.pyx
 
-ext:
+ext: cython
 	@echo
 	@echo "Building extension"
 	@echo "=================="


### PR DESCRIPTION
The failure was:

```
Running Cython
Building extension
==============
==================

cython --version

python setup.py build_ext --inplace --force
Cython version 0.23.4
cython --cplus --fast-fail --annotate plyvel/_plyvel.pyx
running build_ext
building 'plyvel._plyvel' extension
creating build
creating build/temp.linux-x86_64-3.5
creating build/temp.linux-x86_64-3.5/plyvel
gcc -pthread -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.5m -c plyvel/_plyvel.cpp -o build/temp.linux-x86_64-3.5/plyvel/_plyvel.o -Wall -g
gcc: error: plyvel/_plyvel.cpp: No such file or directory
gcc: fatal error: no input files
compilation terminated.
error: command 'gcc' failed with exit status 1
Makefile:15: recipe for target 'ext' failed
make: *** [ext] Error 1
make: *** Waiting for unfinished jobs....
```

Fixed after applying the dependency.