### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ See the documentation and project page for more information:
 * `PyPI page`_
 
 .. _Project page: https://github.com/wbolster/plyvel
-.. _Documentation: https://plyvel.readthedocs.org/
+.. _Documentation: https://plyvel.readthedocs.io/
 .. _PyPI page: http://pypi.python.org/pypi/plyvel/
 .. _LevelDB: http://code.google.com/p/leveldb/
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,7 +63,7 @@ let me know you appreciate my work. Thanks!
 
 .. rubric:: External links
 
-* `Online documentation <https://plyvel.readthedocs.org/>`_ (Read the docs)
+* `Online documentation <https://plyvel.readthedocs.io/>`_ (Read the docs)
 * `Project page <https://github.com/wbolster/plyvel>`_ with source code and
   issue tracker (Github)
 * `Python Package Index (PyPI) page <http://pypi.python.org/pypi/plyvel/>`_ with


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.