### PR TITLE
add docker infrastructure to build manylinux1 wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerfile for building manylinux1 wheels.
+#
+# Usage:
+#
+#   docker build -t plyvel-build .
+#   docker run -i -t -v $(pwd)/dist/:/wheelhouse plyvel-build
+#
+# The .whl files should appear in dist/ on the host.
+
+FROM quay.io/pypa/manylinux1_x86_64
+
+ENV LC_ALL=en_US.UTF-8
+ENV LEVELDB_VERSION=1.20
+ENV PATH="/opt/python/cp36-cp36m/bin:${PATH}"
+ENV PROJECT_ROOT="/opt/plyvel"
+
+RUN true \
+    && mkdir /opt/leveldb \
+    && cd /opt/leveldb \
+    && wget -O leveldb.tar.gz https://github.com/google/leveldb/archive/v${LEVELDB_VERSION}.tar.gz \
+    && tar xf leveldb.tar.gz \
+    && cd leveldb-${LEVELDB_VERSION}/ \
+    && make -j4 \
+    && cp -av out-static/lib* out-shared/lib* /usr/local/lib/ \
+    && cp -av include/leveldb/ /usr/local/include/ \
+    && ldconfig
+
+RUN pip install --upgrade pip setuptools tox cython
+
+COPY . $PROJECT_ROOT
+
+WORKDIR $PROJECT_ROOT
+
+CMD true \
+    && git clean -xfd \
+    && make wheels

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-.PHONY: all cython ext doc clean test
+.PHONY: all cython ext doc clean test wheels
 
 all: cython ext
 
@@ -47,3 +46,17 @@ test: ext
 	@echo "============="
 	@echo
 	py.test
+
+wheels: cython
+	# Note: this should run inside the docker container.
+	@echo
+	@echo "Building wheels"
+	@echo "==============="
+	@echo
+	for dir in /opt/python/*; do \
+		$${dir}/bin/python setup.py bdist_wheel; \
+	done
+	for wheel in dist/*.whl; do \
+		auditwheel show $${wheel}; \
+		auditwheel repair -w /wheelhouse/ $${wheel}; \
+	done


### PR DESCRIPTION
this adds a Dockerfile that uses the
quay.io/pypa/manylinux1_x86_64 base image.

it builds and installs leveldb from source,
then builds plyvel wheels with leveldb embedded
for various python versions.

publishing these wheels on pypi would mean that
‘pip install plyvel’ on linux will install pre-built
binary packages, which should simplify installation
for many users.