### PR TITLE
Remove reference to non-existent _static directory from Sphinx config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,6 @@ release = __version__
 autodoc_default_flags = ['members', 'undoc-members']
 autodoc_member_order = 'bysource'
 
-html_static_path = ['_static']
 html_domain_indices = False
 html_show_sourcelink = False
 html_show_sphinx = False


### PR DESCRIPTION
Hi,
This fixes the following error:
```
copying static files... WARNING: html_static_path entry '/tmp/plyvel/doc/_static' does not exist                                                                                                       
```