### PR TITLE
Expose DB name attribute at the Python level

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -64,6 +64,13 @@ LevelDB database.
       :param bytes comparator_name: name for the custom comparator
 
 
+   .. py:attribute:: name
+
+      The (directory) name of this :py:class:`DB` instance. This is a
+      *read-only* attribute and must be set at instantiation time.
+
+      *New in version 1.1.0.*
+
    .. py:method:: close()
 
       Close the database.

--- a/plyvel/_plyvel.pyx
+++ b/plyvel/_plyvel.pyx
@@ -221,7 +221,7 @@ cdef int parse_options(Options *options, c_bool create_if_missing,
 cdef class DB:
     cdef leveldb.DB* _db
     cdef Options options
-    cdef object name
+    cdef readonly object name
     cdef object lock
     cdef dict iterators
 

--- a/test/test_plyvel.py
+++ b/test/test_plyvel.py
@@ -1134,3 +1134,14 @@ def test_raw_iterator_closing(db):
         with db.raw_iterator() as it:
             pass
         it.valid()
+
+
+def test_access_DB_name_attr(db_dir):
+    db = plyvel.DB(db_dir, create_if_missing=True)
+    assert db.name == db_dir
+
+
+def test_try_changing_DB_name_attr(db_dir):
+    db = plyvel.DB(db_dir, create_if_missing=True)
+    with pytest.raises(AttributeError):
+        db.name = 'a'


### PR DESCRIPTION
Related to issue #88.

The `DB.name` attribute is not exposed at the Python level and could sometimes be useful. One example, is the deletion of a DB instance for which the `name` has not been "cached" at creation time. One could get the name by parsing `DB.__str__()` or `DB.__repr__()` but why not directly from `DB.name`?