### PR TITLE
Use -x c++ to enable C++ mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from os.path import join, dirname
 from setuptools import setup
 from setuptools.extension import Extension
-import platform
 
 CURRENT_DIR = dirname(__file__)
 
@@ -14,9 +13,7 @@ def get_file_contents(filename):
         return fp.read()
 
 
-extra_compile_args = ['-Wall', '-g']
-if platform.system() == 'Darwin':
-    extra_compile_args += ['-mmacosx-version-min=10.7', '-stdlib=libc++']
+extra_compile_args = ['-Wall', '-g', '-x', 'c++']
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
Use the generic flags `-x c++` to enable C++ mode, instead of the Clang-specific `-stdlib=libc++` and Mac-specific `-mmacosx-version-min=10.7`.

Fixes build failure on Mac OS X 10.6.

This reverts part of #67 and fixes it a different way.

The reason why any fix was necessary in the first place is that apparently distutils compiles all code, even C++ code, using the C compiler. This seems to be a [longstanding distutils bug](https://bugs.python.org/issue1222585). The C compiler of course doesn't expect C++ code, which appears to be what caused the missing symbols mentioned in #66. (It appears that only some systems are affected. Reverting the change from #67, I see the missing symbol errors on OS X 10.8, but not on macOS 10.13. It may depend on the clang version or on which C++ standard library is used. #66 doesn't mention what version of macOS was being used there.)

The solution implemented in #67 was to enable C++ mode in the C compiler by using the flag `-stdlib=libc++`. And libc++ was first shipped in Mac OS X 10.7, so the flag `-mmacosx-version-min=10.7` was added.

This causes build failure on Mac OS X 10.6 and earlier, because those OS versions don't use clang by default, and only clang understands `-stdlib`:

```
cc1plus: error: unrecognized command line option "-stdlib=libc++"
error: command '/usr/bin/gcc-4.2' failed with exit status 1
```

The plyvel code isn't doing anything that's specific to libc++ or Mac OS X 10.7 or later, and it compiles fine using libstdc++, which is the default C++ standard library on OS X 10.8 and earlier. The revised solution implemented in this PR is to enable C++ mode in the C compiler using the standard `-x c++` flag instead. I have verified this compiles fine on Mac OS X 10.6 and that a test file containing `import plyvel` runs without showing any missing symbol errors.