### PR TITLE
Fix OSX Build issue

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest
+pytest>=3.6
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from os.path import join, dirname
 from setuptools import setup
 from setuptools.extension import Extension
-import platform
 
 CURRENT_DIR = dirname(__file__)
 
@@ -14,9 +13,7 @@ def get_file_contents(filename):
         return fp.read()
 
 
-extra_compile_args = ['-Wall', '-g']
-if platform.system() == 'Darwin':
-    extra_compile_args += ['-mmacosx-version-min=10.7', '-stdlib=libc++']
+extra_compile_args = ['-Wall', '-g', '-x', 'c++', '-std=c++11']
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
Okay here goes again:
Via adding the extra compile arguments of `-x c++ -std=c++11` and removing platform specific code as suggested by @kyuupichan and @wbolster in #95 plyvel now builds on OSX 10.14. This PR should fix #95 I'm using OSX 10.14 and `make` and `make test` are both working on my system using python 3.7.3