### PR TITLE
prepare for 1.0.6 release

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,15 @@
 Version history
 ===============
 
+Plyvel 1.0.6
+============
+
+Release date: 2019-04-19
+
+* Fix building sources on OSX.
+  (`issue #95 <https://github.com/wbolster/plyvel/issues/95>`_,
+  `pr #97 <https://github.com/wbolster/plyvel/pull/97>`_)
+
 Plyvel 1.0.5
 ============
 

--- a/plyvel/_version.py
+++ b/plyvel/_version.py
@@ -5,4 +5,4 @@ Plyvel version module.
 # Note: don't add any non-trivial logic here; this file is also loaded
 # from setup.py file when the module has not yet been compiled!
 
-__version__ = '1.0.5'
+__version__ = '1.0.6'


### PR DESCRIPTION
This PR prepares the plyvel package for 1.0.6 which includes changes made in #97 resolving the OSX build issue detailed in #95 