### PR TITLE
Replace deprecated autodoc_default_flags with autodoc_default_options

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@ copyright = u'2012‒{}, Wouter Bolsterlee'.format(
 version = __version__
 release = __version__
 
-autodoc_default_flags = ['members', 'undoc-members']
+autodoc_default_options = {"members": True, "undoc-members": True}
 autodoc_member_order = 'bysource'
 
 html_domain_indices = False


### PR DESCRIPTION
Since Sphinx 1.8, the old option yields the following warning:
```
/usr/lib/python3.8/site-packages/sphinx/events.py:76: RemovedInSphinx30Warning: autodoc_default_flags is now deprecated. Please use autodoc_default_options instead.
```