### PR TITLE
Expose WriteBatch.append() and .approximate_size()

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,12 @@ Plyvel 1.4.0
 
 Release date: TBD
 
+* The minimum LevelDB version is now 1.21
+
+* Add support for :py:meth:`WriteBatch.append()`
+
+* Add support for :py:meth:`WriteBatch.approximate_size()`
+
 Plyvel 1.3.0
 ============
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -407,6 +407,15 @@ Write batch
       a context manager (in a ``with`` block), this method will be invoked
       automatically.
 
+   .. py:method:: append(source)
+
+      Copy the operations in `source` (another
+      :py:class:`WriteBatch` instance) to this batch.
+
+   .. py:method:: approximate_size()
+
+      Return the size of the database changes caused by this batch.
+
 
 Snapshot
 ========

--- a/plyvel/_plyvel.pyx
+++ b/plyvel/_plyvel.pyx
@@ -616,6 +616,18 @@ cdef class WriteBatch:
             st = self.db._db.Write(self.write_options, self._write_batch)
         raise_for_status(st)
 
+    def approximate_size(self):
+        if self.db._db is NULL:
+            raise RuntimeError("Database is closed")
+
+        return self._write_batch.ApproximateSize()
+
+    def append(self, WriteBatch source not None):
+        if self.db._db is NULL:
+            raise RuntimeError("Database is closed")
+
+        self._write_batch.Append(source._write_batch[0])
+
     def __enter__(self):
         if self.db._db is NULL:
             raise RuntimeError("Database is closed")

--- a/plyvel/leveldb.pxd
+++ b/plyvel/leveldb.pxd
@@ -110,7 +110,9 @@ cdef extern from "leveldb/write_batch.h" namespace "leveldb":
         void Put(Slice& key, Slice& value) nogil
         void Delete(Slice& key) nogil
         void Clear() nogil
-        # Status Iterate(Handler* handler) const
+        size_t ApproximateSize() nogil
+        void Append(WriteBatch& source) nogil
+        # Status Iterate(Handler* handler)
 
 
 cdef extern from "leveldb/iterator.h" namespace "leveldb":

--- a/test/test_plyvel.py
+++ b/test/test_plyvel.py
@@ -293,6 +293,30 @@ def test_write_batch_bytes_like(db):
     assert db.get(b'b') == b'bar'
 
 
+def test_write_batch_append(db):
+    wb = db.write_batch()
+    wb.put(b'a', b'aa')
+
+    other_wb = db.write_batch()
+    other_wb.put(b'b', b'bb')
+
+    wb.append(other_wb)
+    wb.write()
+
+    assert db.get(b'a') == b'aa'
+    assert db.get(b'b') == b'bb'
+
+
+def test_write_batch_approximate_size(db):
+    wb = db.write_batch()
+    initial_size = wb.approximate_size()
+    wb.put(b'a', b'aa')
+    wb.put(b'b', b'bb')
+    wb.delete(b'b')
+    final_size = wb.approximate_size()
+    assert initial_size < final_size
+
+
 def test_iteration(db):
     entries = []
     for i in range(100):


### PR DESCRIPTION
This adds support for :py:meth:`WriteBatch.append()` (since LevelDB
1.21) and :py:meth:`WriteBatch.approximate_size()` (not exposed before).