### PR TITLE
Add github actions CI/CD to build Linux and MacOS wheels for latest `leveldb 1.23` and `snappy 1.1.9`

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,94 @@
+name: plyvel build
+
+on: [push, pull_request]
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    
+    - name: Install Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools
+        pip install -r requirements-dev.txt
+
+    - name: Build sdist
+      run: python setup.py sdist
+    
+    - name: Save sdist
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+        
+  wheel:
+    name: ${{ matrix.os }}-${{ matrix.cibw.arch }}-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            name: mac-intel
+            cibw:
+              arch: x86_64
+              build: "cp37* cp38* cp39*"
+
+          - os: macos-latest
+            name: mac-arm
+            cibw:
+              arch: universal2
+              build: "cp39*"
+
+          - os: ubuntu-latest
+            name: manylinux
+            cibw:
+              arch: "auto aarch64"
+              build: "cp37* cp38* cp39*"
+  
+    env:
+      CIBW_BUILD: "${{ matrix.cibw.build || '*' }}"
+      CIBW_ENVIRONMENT_MACOS: "C_INCLUDE_PATH=/usr/local/include CPLUS_INCLUDE_PATH=/usr/local/include LIBRARY_PATH=/usr/local/lib"
+      CIBW_ARCHS_LINUX: "${{ matrix.cibw.arch || 'auto' }}"
+      CIBW_ARCHS_MACOS: "${{ matrix.cibw.arch || 'auto' }}"
+      CIBW_BEFORE_ALL_LINUX: "gcc -v && bash scripts/install-snappy.sh && bash scripts/install-leveldb.sh"
+      CIBW_BEFORE_ALL_MACOS: "clang -v && bash scripts/install-snappy.sh && bash scripts/install-leveldb.sh"      
+      CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && delocate-wheel -w {dest_dir} -v {wheel}"
+
+      # Build using the manylinux2014 image instead of manylinux2010
+      # CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      # CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+      # CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Install cibuildwheel
+      run: |
+        pip install -U setuptools pip wheel
+        pip install -U cibuildwheel
+
+    - name: Build
+      run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v2
+      with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,53 @@
+name: plyvel test
+
+on: [push, pull_request]
+
+jobs:
+
+  test:
+    name: ${{ matrix.os }}-${{matrix.python-version}}-test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: sudo apt-get install libleveldb-dev libsnappy-dev
+
+    - name: Install MacOS Dependencies
+      if: runner.os == 'macOS'
+      run: brew install snappy leveldb
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Show Python arch
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          file `which python`
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          file `which python`
+        else
+          echo "$RUNNER_OS not supported"
+          exit 1
+        fi
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
+    
+    - name: Build and Install package
+      run: |
+        python setup.py install
+
+    - name: Run pytest
+      run: |
+        pytest test/test_plyvel.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 plyvel/_plyvel.cpp
 plyvel/_plyvel.html
 plyvel/_plyvel*.so
+
+.venv39/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 	find . -name __pycache__ -delete
 
 test: ext
-	pytest
+	python -m pytest
 
 docker-build-env:
 	docker build -t plyvel-build .

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ Plyvel
 
 .. image:: https://travis-ci.org/wbolster/plyvel.svg?branch=master
     :target: https://travis-ci.org/wbolster/plyvel
+.. image:: https://github.com/liviaerxin/plyvel/actions/workflows/cibuildwheel.yml/badge.svg?branch=CI
+    :target: https://github.com/liviaerxin/plyvel/tree/CI
 
 **Plyvel** is a fast and feature-rich Python interface to LevelDB_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "Cython",
+]
+
+build-backend = "setuptools.build_meta"

--- a/scripts/inline.patch
+++ b/scripts/inline.patch
@@ -1,0 +1,12 @@
+Add inline with SNAPPY_ATTRIBUTE_ALWAYS_INLINE on AdvanceToNextTag to fix:
+1097 |         size_t tag_type = AdvanceToNextTag(&ip, &tag);
+     |                           ~~~~~~~~~~~~~~~~^~~~~~~~~~~
+../snappy.cc:1017:8: error: inlining failed in call to 'always_inline'
+'size_t snappy::AdvanceToNextTag(const uint8_t**, size_t*)': function body can be overwritten at link time
+[patch from here](https://github.com/google/snappy/pull/128)
+
+--- snappy.cc	2021-07-20 16:01:01.000000000 +0800
++++ snappy.cc	2021-07-20 16:08:06.000000000 +0800
+@@ -1017 +1017 @@
+-size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
++inline size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {

--- a/scripts/install-leveldb.sh
+++ b/scripts/install-leveldb.sh
@@ -1,22 +1,72 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eux
+set -ex
 
 SUDO=$(command -v sudo || true)
 
-LEVELDB_VERSION=1.22
+if [[ "$(uname)" == "Darwin" ]]; then
+    ARCHS="x86_64"
+    case "${CIBW_ARCHS_MACOS:-auto}" in
+        "universal2")
+            ARCHS="x86_64 arm64"
+            ;;
+        "arm64")
+            ARCHS="arm64"
+            ;;
+        "x86_64")
+            ARCHS="x86_64"
+            ;;
+        "auto")
+            ;;
+        *)
+            echo "Unexpected arch: ${CIBW_ARCHS_MACOS}"
+            exit 1
+            ;;
+    esac
+    echo "building libleveldb for mac ${ARCHS}"
+    for arch in ${ARCHS}; do
+        export CFLAGS="-arch ${arch} ${CFLAGS:-}"
+        export CXXFLAGS="-arch ${arch} ${CXXFLAGS:-}"
+        export LDFLAGS="-arch ${arch} ${LDFLAGS:-}"
+    done
+fi
 
-mkdir /opt/leveldb
-cd /opt/leveldb
+if [[ "$(uname)" == "Darwin" ]]; then
+    export C_INCLUDE_PATH=/usr/local/include # where find snappy header files
+    export CPLUS_INCLUDE_PATH=/usr/local/include # where find snappy header files
+    export LIBRARY_PATH=/usr/local/lib # where find snappy library
+fi
+
+LEVELDB_VERSION=1.23
+
+mkdir -p ~/opt/leveldb
+cd ~/opt/leveldb
 curl -sL leveldb.tar.gz https://codeload.github.com/google/leveldb/tar.gz/${LEVELDB_VERSION} | tar xzf -
 cd leveldb-*
+
+# `CMAKE_INSTALL_NAME_DIR` and `CMAKE_SKIP_INSTALL_RPATH` only have effect for MacOS
+if [[ "$(uname)" == "Darwin" ]]; then
+    INSTALL_NAME_DIR="/usr/local/lib"
+fi
+
+mkdir -p build && cd build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=on \
-    -DLEVELDB_BUILD_TESTS=off \
-    -DLEVELDB_BUILD_BENCHMARKS=off \
-    .
-cmake --build .
-$SUDO "$(command -v cmake)" --build . --target install
-$SUDO ldconfig
+    -DCMAKE_SKIP_INSTALL_RPATH=OFF \
+    -DCMAKE_INSTALL_NAME_DIR=$INSTALL_NAME_DIR \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DLEVELDB_BUILD_TESTS=OFF \
+    -DLEVELDB_BUILD_BENCHMARKS=OFF \
+    ..
+
+cmake --build . --target install
+
+if [[ "$(uname)" == "Linux" ]]; then
+    which ldconfig && ldconfig || true
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    otool -L $INSTALL_NAME_DIR/libleveldb.dylib
+    file $INSTALL_NAME_DIR/libleveldb.dylib
+fi

--- a/scripts/install-snappy.sh
+++ b/scripts/install-snappy.sh
@@ -1,16 +1,79 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eux
+set -ex
 
 SUDO=$(command -v sudo || true)
+SCRIPT="$( cd "$( dirname $0 )" && pwd )"
+PATCH_FILE=$SCRIPT/inline.patch # for snappy 1.1.9
+echo $PATCH_FILE
 
-SNAPPY_VERSION=1.1.8
+if [[ "$(uname)" == "Darwin" ]]; then
+    ARCHS="x86_64"
+    case "${CIBW_ARCHS_MACOS:-auto}" in
+        "universal2")
+            ARCHS="x86_64 arm64"
+            ;;
+        "arm64")
+            ARCHS="arm64"
+            ;;
+        "x86_64")
+            ARCHS="x86_64"
+            ;;
+        "auto")
+            ;;
+        *)
+            echo "Unexpected arch: ${CIBW_ARCHS_MACOS}"
+            exit 1
+            ;;
+    esac
+    echo "building libsnappy for mac ${ARCHS}"
+    for arch in ${ARCHS}; do
+        export CFLAGS="-arch ${arch} ${CFLAGS:-}"
+        export CXXFLAGS="-arch ${arch} ${CXXFLAGS:-}"
+        export LDFLAGS="-arch ${arch} ${LDFLAGS:-}"
+    done
+fi
 
-mkdir /opt/snappy
-cd /opt/snappy
+SNAPPY_VERSION=1.1.9
+
+mkdir -p ~/opt/snappy
+cd ~/opt/snappy
 curl -sL https://codeload.github.com/google/snappy/tar.gz/${SNAPPY_VERSION} | tar xzf -
 cd ./snappy-*
-cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=on .
-cmake --build .
-$SUDO "$(command -v cmake)" --build . --target install
-$SUDO ldconfig
+
+# Patch inline
+cp $PATCH_FILE .
+echo $PWD
+patch < inline.patch
+
+
+# `CMAKE_INSTALL_NAME_DIR` and `CMAKE_SKIP_INSTALL_RPATH` only have effect for MacOS
+# [CMAKE_SKIP_RPATH/CMAKE_SKIP_INSTALL_RPATH and INSTALL_NAME_DIR precedence on macOS](https://gitlab.kitware.com/cmake/cmake/-/issues/16589)
+# Set `INSTALL_NAME_DIR` to set the install name of shared library to be an absolute path instead of `@rpath/{target_name}`, which will help delocate the `wheel` 
+# Or use `install_name_tool -change <old-path> <new-path> <file>` after .dylib was created
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    INSTALL_NAME_DIR="/usr/local/lib"
+fi
+
+mkdir -p build && cd build
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCMAKE_SKIP_INSTALL_RPATH=OFF \
+    -DCMAKE_INSTALL_NAME_DIR=$INSTALL_NAME_DIR \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DSNAPPY_BUILD_BENCHMARKS=OFF \
+    -DSNAPPY_BUILD_TESTS=OFF \
+    ..
+
+cmake --build . --target install
+
+if [[ "$(uname)" == "Linux" ]]; then
+    which ldconfig && ldconfig || true
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    otool -L $INSTALL_NAME_DIR/libsnappy.dylib
+    file $INSTALL_NAME_DIR/libsnappy.dylib
+fi

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from os.path import join, dirname
 from setuptools import setup
 from setuptools.extension import Extension
 import platform
+from Cython.Build import cythonize
 
 CURRENT_DIR = dirname(__file__)
 
@@ -13,19 +14,20 @@ def get_file_contents(filename):
     with open(join(CURRENT_DIR, filename)) as fp:
         return fp.read()
 
+# add "-fno-rtti" fix `Symbol not found: __ZTIN7leveldb10ComparatorE` when using `leveldb 1.23`. Because `leveldb 1.23` compiled without RTTI(run time type info), if we use "-frtti", `U typeinfo for leveldb::Comparator` will not be found in `leveldb.a` or `leveldb.so`
+extra_compile_args = ['-Wall', '-g', '-x', 'c++', '-std=c++11', '-fno-rtti']
 
-extra_compile_args = ['-Wall', '-g', '-x', 'c++', '-std=c++11']
-
-if platform.system() == 'Darwin':
-    extra_compile_args += ['-stdlib=libc++']
+if platform.system() == "Darwin":
+    extra_compile_args += ["-stdlib=libc++"]
 
 ext_modules = [
     Extension(
         'plyvel._plyvel',
-        sources=['plyvel/_plyvel.cpp', 'plyvel/comparator.cpp'],
+        language="c++",
+        sources=['plyvel/_plyvel.pyx', 'plyvel/comparator.cpp'],
         libraries=['leveldb'],
         extra_compile_args=extra_compile_args,
-    )
+    ),
 ]
 
 setup(
@@ -36,7 +38,7 @@ setup(
     version=__version__,  # noqa: F821
     author="Wouter Bolsterlee",
     author_email="wouter@bolsterl.ee",
-    ext_modules=ext_modules,
+    ext_modules=cythonize(ext_modules, build_dir='build'),
     packages=['plyvel'],
     license="BSD License",
     classifiers=[


### PR DESCRIPTION
New Features:

1.  Support `manylinux_x86_64`, `manylinux_aarch64`, `manylinux_i686` for `cp37* cp38* cp39*` in Linux using `cibuildwheel`
2.  Support `x86_64` for `cp37* cp38* cp39*` and `universal2` for ` cp39*` in MacOS using `cibuildwheel`
3.  Support the latest version `1.23` of `leveldb` and `1.1.9` of `snappy`

Check and verify my [github actions CI/CD built wheels](https://github.com/liviaerxin/plyvel/actions/runs/1068036265)

TODOs:

1. Apply a new version for `plyvel`
2. Support to build Windows wheels  