### PR TITLE
Allow using plyvel.DB as a context manager

### DIFF
--- a/plyvel/_plyvel.pyx
+++ b/plyvel/_plyvel.pyx
@@ -449,6 +449,12 @@ cdef class DB:
     def prefixed_db(self, bytes prefix not None):
         return PrefixedDB(db=self, prefix=prefix)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
 
 cdef class PrefixedDB:
     cdef readonly DB db

--- a/test/test_plyvel.py
+++ b/test/test_plyvel.py
@@ -1164,3 +1164,13 @@ def test_try_changing_DB_name_attr(db_dir):
     db = plyvel.DB(db_dir, create_if_missing=True)
     with pytest.raises(AttributeError):
         db.name = 'a'
+
+
+def test_context_manager(db_dir):
+    key = b'the-key'
+    value = b'the-value'
+    with plyvel.DB(db_dir, create_if_missing=True) as db:
+        db.put(key, value)
+        assert db.get(key) == value
+
+    assert db.closed


### PR DESCRIPTION
Allows for using `with` on plyvel.DB, like this:

``` python
with plyvel.DB(...) as db:
    ...
```

I'm not too familiar with the codebase, but I added a test and it seems to work.
