### PR TITLE
Raise TypeError when attempting ‘in’, ‘not in’, and __contains__

### DIFF
--- a/plyvel/_plyvel.pyx
+++ b/plyvel/_plyvel.pyx
@@ -213,6 +213,10 @@ cdef int parse_options(Options *options, c_bool create_if_missing,
             comparator_name, comparator)
 
 
+def contains_is_unsupported():
+    raise TypeError("__contains__ is not supported ('in' and 'not in' operators)")
+
+
 #
 # Database
 #
@@ -348,6 +352,9 @@ cdef class DB:
             raise RuntimeError("Database is closed")
 
         return WriteBatch(self, None, transaction, sync)
+
+    def __contains__(self, key):
+        contains_is_unsupported()
 
     def __iter__(self):
         if self._db is NULL:
@@ -487,6 +494,9 @@ cdef class PrefixedDB:
 
     def write_batch(self, *, transaction=False, bool sync=False):
         return WriteBatch(self.db, self.prefix, transaction, sync)
+
+    def __contains__(self, key):
+        contains_is_unsupported()
 
     def __iter__(self):
         return self.iterator()
@@ -707,6 +717,9 @@ cdef class BaseIterator:
 
     def __dealloc__(self):
         self.close()
+
+    def __contains__(self, key):
+        contains_is_unsupported()
 
     def __enter__(self):
         return self
@@ -1164,6 +1177,9 @@ cdef class Snapshot:
             key = self.prefix + key
 
         return db_get(self.db, key, default, read_options)
+
+    def __contains__(self, key):
+        contains_is_unsupported()
 
     def __iter__(self):
         return self.iterator()

--- a/test/test_plyvel.py
+++ b/test/test_plyvel.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import functools
 import itertools
 import os
 import random
@@ -1174,3 +1175,33 @@ def test_context_manager(db_dir):
         assert db.get(key) == value
 
     assert db.closed
+
+
+def test_in_operator(db):
+    """The ‘in’ and ‘not in’ operators should not work."""
+    raises = functools.partial(
+        pytest.raises, TypeError, match="__contains__ is not supported"
+    )
+    key = b"key"
+    with raises():
+        key in db
+    with raises():
+        key not in db
+
+    snapshot = db.snapshot()
+    with raises():
+        key in snapshot
+    with raises():
+        key not in snapshot
+
+    prefixed_db = db.prefixed_db(b"k")
+    with raises():
+        key in prefixed_db
+    with raises():
+        key not in prefixed_db
+
+    iterator = iter(db)
+    with raises():
+        key in iterator
+    with raises():
+        key not in iterator


### PR DESCRIPTION
The ‘in’ operator has fallback behaviour for objects that do not specify `__contains__`, see
https://docs.python.org/3/reference/expressions.html#membership-test-details

Various Plyvel classes have `.__iter__()` methods, so this means that ‘key in db’ actually iterates over the db, which yields ‘(key, value)’ tuples, none of which will be equal to plain ‘key’. For comparison, (key, value) in db actually works… accidentally!

For non-matches (always in practice) such as an innocent looking key lookup means the whole database is iterated (extremely slow for larger databases), and will always return False in the end. This is unexpected and bad behaviour.

Instead, detect this and raise TypeError with a helpful error message.

Closes #26.